### PR TITLE
Use fully qualified name for `Get-ScheduledTask` to avoid conflicting…

### DIFF
--- a/docs/ChangeLog.md
+++ b/docs/ChangeLog.md
@@ -2,6 +2,10 @@
 
 This page is a list of *notable* changes made to the Windows Scheduled Tasks Azure DevOps extension.
 
+## November 26, 2019 - v2.0.7
+
+- fix: Use fully qualified name for `Get-ScheduledTask` to avoid conflicting with the `Carbon` module on the target servers if it's installed.
+
 ## May 15, 2019 - v2.0.0
 
 - feature: Allow all authentication types supported by WinRM; not just CredSSP.

--- a/src/Tasks/DisableWindowsScheduledTask/Code/Disable-WindowsScheduledTask.psm1
+++ b/src/Tasks/DisableWindowsScheduledTask/Code/Disable-WindowsScheduledTask.psm1
@@ -73,7 +73,7 @@ function Disable-WindowsScheduledTask
 			[string] $taskPath = $scheduledTaskSettings.ScheduledTaskPath
 
 			Write-Verbose "Searching for a Scheduled Task with the path '$taskPath' and name '$taskName'." -Verbose
-			$tasks = Get-ScheduledTask -TaskName $taskName -TaskPath $taskPath -ErrorAction SilentlyContinue
+			$tasks = ScheduledTasks\Get-ScheduledTask -TaskName $taskName -TaskPath $taskPath -ErrorAction SilentlyContinue
 			if ($null -eq $tasks)
 			{
 				[string] $taskPathAndName = $taskPath + $taskName

--- a/src/Tasks/EnableWindowsScheduledTask/Code/Enable-WindowsScheduledTask.psm1
+++ b/src/Tasks/EnableWindowsScheduledTask/Code/Enable-WindowsScheduledTask.psm1
@@ -73,7 +73,7 @@ function Enable-WindowsScheduledTask
 			[string] $taskPath = $scheduledTaskSettings.ScheduledTaskPath
 
 			Write-Verbose "Searching for a Scheduled Task with the path '$taskPath' and name '$taskName'." -Verbose
-			$tasks = Get-ScheduledTask -TaskName $taskName -TaskPath $taskPath -ErrorAction SilentlyContinue
+			$tasks = ScheduledTasks\Get-ScheduledTask -TaskName $taskName -TaskPath $taskPath -ErrorAction SilentlyContinue
 			if ($null -eq $tasks)
 			{
 				[string] $taskPathAndName = $taskPath + $taskName

--- a/src/Tasks/StartWindowsScheduledTask/Code/Start-WindowsScheduledTask.psm1
+++ b/src/Tasks/StartWindowsScheduledTask/Code/Start-WindowsScheduledTask.psm1
@@ -73,7 +73,7 @@ function Start-WindowsScheduledTask
 			[string] $taskPath = $scheduledTaskSettings.ScheduledTaskPath
 
 			Write-Verbose "Searching for a Scheduled Task with the path '$taskPath' and name '$taskName'." -Verbose
-			$tasks = Get-ScheduledTask -TaskName $taskName -TaskPath $taskPath -ErrorAction SilentlyContinue
+			$tasks = ScheduledTasks\Get-ScheduledTask -TaskName $taskName -TaskPath $taskPath -ErrorAction SilentlyContinue
 			if ($null -eq $tasks)
 			{
 				[string] $taskPathAndName = $taskPath + $taskName

--- a/src/Tasks/StopWindowsScheduledTask/Code/Stop-WindowsScheduledTask.psm1
+++ b/src/Tasks/StopWindowsScheduledTask/Code/Stop-WindowsScheduledTask.psm1
@@ -73,7 +73,7 @@ function Stop-WindowsScheduledTask
 			[string] $taskPath = $scheduledTaskSettings.ScheduledTaskPath
 
 			Write-Verbose "Searching for a Scheduled Task with the path '$taskPath' and name '$taskName'." -Verbose
-			$tasks = Get-ScheduledTask -TaskName $taskName -TaskPath $taskPath -ErrorAction SilentlyContinue
+			$tasks = ScheduledTasks\Get-ScheduledTask -TaskName $taskName -TaskPath $taskPath -ErrorAction SilentlyContinue
 			if ($null -eq $tasks)
 			{
 				[string] $taskPathAndName = $taskPath + $taskName

--- a/src/Tasks/UninstallWindowsScheduledTask/Code/Uninstall-WindowsScheduledTask.psm1
+++ b/src/Tasks/UninstallWindowsScheduledTask/Code/Uninstall-WindowsScheduledTask.psm1
@@ -73,7 +73,7 @@ function Uninstall-WindowsScheduledTask
 			[string] $taskPath = $scheduledTaskSettings.ScheduledTaskPath
 
 			Write-Verbose "Searching for a Scheduled Task with the path '$taskPath' and name '$taskName'." -Verbose
-			$tasks = Get-ScheduledTask -TaskName $taskName -TaskPath $taskPath -ErrorAction SilentlyContinue
+			$tasks = ScheduledTasks\Get-ScheduledTask -TaskName $taskName -TaskPath $taskPath -ErrorAction SilentlyContinue
 			if ($null -eq $tasks)
 			{
 				[string] $taskPathAndName = $taskPath + $taskName


### PR DESCRIPTION
… with the `Carbon` module on the target servers if it's installed.