### PR TITLE
Allow empty user to be used

### DIFF
--- a/src/SharedTaskCode/UserInputToScheduledTaskMapper.psm1
+++ b/src/SharedTaskCode/UserInputToScheduledTaskMapper.psm1
@@ -19,7 +19,7 @@ function Get-AccountCredentialsToRunScheduledTaskAs
 {
 	param
 	(
-		[ValidateSet('System', 'LocalService', 'NetworkService', 'CustomAccount')]
+		[ValidateSet('System', 'LocalService', 'NetworkService', 'CustomAccount', 'PrincipalFromXml')]
 		[string] $scheduldTaskAccountToRunAsOptions,
 		[string] $customAccountToRunScheduledTaskAsUsername,
 		[string] $customAccountToRunScheduledTaskAsPassword
@@ -32,6 +32,7 @@ function Get-AccountCredentialsToRunScheduledTaskAs
 		"System" { $username = 'NT AUTHORITY\SYSTEM'; break }
 		"LocalService" { $username = 'NT AUTHORITY\LOCALSERVICE'; break }
 		"NetworkService" { $username = 'NT AUTHORITY\NETWORKSERVICE'; break }
+		"PrincipalFromXml" { $username = $null; break; }
 		default
 		{
 			$username = $customAccountToRunScheduledTaskAsUsername

--- a/src/Tasks/DisableWindowsScheduledTask/Code/Shared/UserInputToScheduledTaskMapper.psm1
+++ b/src/Tasks/DisableWindowsScheduledTask/Code/Shared/UserInputToScheduledTaskMapper.psm1
@@ -19,7 +19,7 @@ function Get-AccountCredentialsToRunScheduledTaskAs
 {
 	param
 	(
-		[ValidateSet('System', 'LocalService', 'NetworkService', 'CustomAccount')]
+		[ValidateSet('System', 'LocalService', 'NetworkService', 'CustomAccount', 'PrincipalFromXml')]
 		[string] $scheduldTaskAccountToRunAsOptions,
 		[string] $customAccountToRunScheduledTaskAsUsername,
 		[string] $customAccountToRunScheduledTaskAsPassword
@@ -32,6 +32,7 @@ function Get-AccountCredentialsToRunScheduledTaskAs
 		"System" { $username = 'NT AUTHORITY\SYSTEM'; break }
 		"LocalService" { $username = 'NT AUTHORITY\LOCALSERVICE'; break }
 		"NetworkService" { $username = 'NT AUTHORITY\NETWORKSERVICE'; break }
+		"PrincipalFromXml" { $username = $null; break; }
 		default
 		{
 			$username = $customAccountToRunScheduledTaskAsUsername

--- a/src/Tasks/EnableWindowsScheduledTask/Code/Shared/UserInputToScheduledTaskMapper.psm1
+++ b/src/Tasks/EnableWindowsScheduledTask/Code/Shared/UserInputToScheduledTaskMapper.psm1
@@ -19,7 +19,7 @@ function Get-AccountCredentialsToRunScheduledTaskAs
 {
 	param
 	(
-		[ValidateSet('System', 'LocalService', 'NetworkService', 'CustomAccount')]
+		[ValidateSet('System', 'LocalService', 'NetworkService', 'CustomAccount', 'PrincipalFromXml')]
 		[string] $scheduldTaskAccountToRunAsOptions,
 		[string] $customAccountToRunScheduledTaskAsUsername,
 		[string] $customAccountToRunScheduledTaskAsPassword
@@ -32,6 +32,7 @@ function Get-AccountCredentialsToRunScheduledTaskAs
 		"System" { $username = 'NT AUTHORITY\SYSTEM'; break }
 		"LocalService" { $username = 'NT AUTHORITY\LOCALSERVICE'; break }
 		"NetworkService" { $username = 'NT AUTHORITY\NETWORKSERVICE'; break }
+		"PrincipalFromXml" { $username = $null; break; }
 		default
 		{
 			$username = $customAccountToRunScheduledTaskAsUsername

--- a/src/Tasks/InstallWindowsScheduledTask/Code/Install-WindowsScheduledTask-TaskEntryPoint.ps1
+++ b/src/Tasks/InstallWindowsScheduledTask/Code/Install-WindowsScheduledTask-TaskEntryPoint.ps1
@@ -84,7 +84,7 @@ param
 	[string] $ScheduleStartTimeRandomDelayInMinutes,
 
 	[parameter(Mandatory=$false,HelpMessage="Options for the account that the Scheduled Task should run as.")]
-	[ValidateSet('System', 'LocalService', 'NetworkService', 'CustomAccount')]
+	[ValidateSet('System', 'LocalService', 'NetworkService', 'CustomAccount', 'PrincipalFromXml')]
 	[string] $ScheduledTaskAccountToRunAsOptions,
 
 	[parameter(Mandatory=$false,HelpMessage="The Username of the custom account that the Scheduled Task should run as.")]

--- a/src/Tasks/InstallWindowsScheduledTask/Code/Shared/UserInputToScheduledTaskMapper.psm1
+++ b/src/Tasks/InstallWindowsScheduledTask/Code/Shared/UserInputToScheduledTaskMapper.psm1
@@ -19,7 +19,7 @@ function Get-AccountCredentialsToRunScheduledTaskAs
 {
 	param
 	(
-		[ValidateSet('System', 'LocalService', 'NetworkService', 'CustomAccount')]
+		[ValidateSet('System', 'LocalService', 'NetworkService', 'CustomAccount', 'PrincipalFromXml')]
 		[string] $scheduldTaskAccountToRunAsOptions,
 		[string] $customAccountToRunScheduledTaskAsUsername,
 		[string] $customAccountToRunScheduledTaskAsPassword
@@ -32,6 +32,7 @@ function Get-AccountCredentialsToRunScheduledTaskAs
 		"System" { $username = 'NT AUTHORITY\SYSTEM'; break }
 		"LocalService" { $username = 'NT AUTHORITY\LOCALSERVICE'; break }
 		"NetworkService" { $username = 'NT AUTHORITY\NETWORKSERVICE'; break }
+		"PrincipalFromXml" { $username = $null; break; }
 		default
 		{
 			$username = $customAccountToRunScheduledTaskAsUsername

--- a/src/Tasks/InstallWindowsScheduledTask/task.json
+++ b/src/Tasks/InstallWindowsScheduledTask/task.json
@@ -317,7 +317,8 @@
 				"System": "System",
 				"LocalService": "Local Service",
 				"NetworkService": "Network Service",
-				"CustomAccount": "Custom User or Service Account"
+				"CustomAccount": "Custom User or Service Account",
+				"PrincipalFromXml": "Principal from XML"
 			},
 			"groupName": "ScheduledTaskSettings"
 		},

--- a/src/Tasks/StartWindowsScheduledTask/Code/Shared/UserInputToScheduledTaskMapper.psm1
+++ b/src/Tasks/StartWindowsScheduledTask/Code/Shared/UserInputToScheduledTaskMapper.psm1
@@ -19,7 +19,7 @@ function Get-AccountCredentialsToRunScheduledTaskAs
 {
 	param
 	(
-		[ValidateSet('System', 'LocalService', 'NetworkService', 'CustomAccount')]
+		[ValidateSet('System', 'LocalService', 'NetworkService', 'CustomAccount', 'PrincipalFromXml')]
 		[string] $scheduldTaskAccountToRunAsOptions,
 		[string] $customAccountToRunScheduledTaskAsUsername,
 		[string] $customAccountToRunScheduledTaskAsPassword
@@ -32,6 +32,7 @@ function Get-AccountCredentialsToRunScheduledTaskAs
 		"System" { $username = 'NT AUTHORITY\SYSTEM'; break }
 		"LocalService" { $username = 'NT AUTHORITY\LOCALSERVICE'; break }
 		"NetworkService" { $username = 'NT AUTHORITY\NETWORKSERVICE'; break }
+		"PrincipalFromXml" { $username = $null; break; }
 		default
 		{
 			$username = $customAccountToRunScheduledTaskAsUsername

--- a/src/Tasks/StopWindowsScheduledTask/Code/Shared/UserInputToScheduledTaskMapper.psm1
+++ b/src/Tasks/StopWindowsScheduledTask/Code/Shared/UserInputToScheduledTaskMapper.psm1
@@ -19,7 +19,7 @@ function Get-AccountCredentialsToRunScheduledTaskAs
 {
 	param
 	(
-		[ValidateSet('System', 'LocalService', 'NetworkService', 'CustomAccount')]
+		[ValidateSet('System', 'LocalService', 'NetworkService', 'CustomAccount', 'PrincipalFromXml')]
 		[string] $scheduldTaskAccountToRunAsOptions,
 		[string] $customAccountToRunScheduledTaskAsUsername,
 		[string] $customAccountToRunScheduledTaskAsPassword
@@ -32,6 +32,7 @@ function Get-AccountCredentialsToRunScheduledTaskAs
 		"System" { $username = 'NT AUTHORITY\SYSTEM'; break }
 		"LocalService" { $username = 'NT AUTHORITY\LOCALSERVICE'; break }
 		"NetworkService" { $username = 'NT AUTHORITY\NETWORKSERVICE'; break }
+		"PrincipalFromXml" { $username = $null; break; }
 		default
 		{
 			$username = $customAccountToRunScheduledTaskAsUsername

--- a/src/Tasks/UninstallWindowsScheduledTask/Code/Shared/UserInputToScheduledTaskMapper.psm1
+++ b/src/Tasks/UninstallWindowsScheduledTask/Code/Shared/UserInputToScheduledTaskMapper.psm1
@@ -19,7 +19,7 @@ function Get-AccountCredentialsToRunScheduledTaskAs
 {
 	param
 	(
-		[ValidateSet('System', 'LocalService', 'NetworkService', 'CustomAccount')]
+		[ValidateSet('System', 'LocalService', 'NetworkService', 'CustomAccount', 'PrincipalFromXml')]
 		[string] $scheduldTaskAccountToRunAsOptions,
 		[string] $customAccountToRunScheduledTaskAsUsername,
 		[string] $customAccountToRunScheduledTaskAsPassword
@@ -32,6 +32,7 @@ function Get-AccountCredentialsToRunScheduledTaskAs
 		"System" { $username = 'NT AUTHORITY\SYSTEM'; break }
 		"LocalService" { $username = 'NT AUTHORITY\LOCALSERVICE'; break }
 		"NetworkService" { $username = 'NT AUTHORITY\NETWORKSERVICE'; break }
+		"PrincipalFromXml" { $username = $null; break; }
 		default
 		{
 			$username = $customAccountToRunScheduledTaskAsUsername


### PR DESCRIPTION
Amends #21 which was described in #20 

These changes should allow one to set the username to an empty value.